### PR TITLE
Only include railties if Rails is loaded

### DIFF
--- a/lib/talk_like_a_pirate.rb
+++ b/lib/talk_like_a_pirate.rb
@@ -73,4 +73,4 @@ private #####################################################################
 
 end
 
-require 'talk_like_a_pirate/railties'
+require 'talk_like_a_pirate/railties' if Object.const_defined? :Rails


### PR DESCRIPTION
This means we can extend non-rails projects with piratey goodness.
