### PR TITLE
Update to support rails/activesupport 6.0.0

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -25,3 +25,7 @@ end
 appraise "rails-5-2" do
   gem "activesupport", "~> 5.2.0"
 end
+
+appraise "rails-6-0" do
+  gem "activesupport", "~> 6.0.0"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,45 +1,47 @@
 PATH
   remote: .
   specs:
-    talk_like_a_pirate (0.2.0)
-      activesupport (>= 3.0.0, < 6.0.0)
+    talk_like_a_pirate (0.2.1)
+      activesupport (>= 3.0.0, < 6.0.1)
       i18n
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.1)
+    activesupport (6.0.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+      zeitwerk (~> 2.1, >= 2.1.8)
     appraisal (2.2.0)
       bundler
       rake
       thor (>= 0.14.0)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.5)
     diff-lcs (1.3)
-    i18n (1.1.0)
+    i18n (1.7.0)
       concurrent-ruby (~> 1.0)
-    minitest (5.11.3)
-    rake (10.0.4)
-    rspec (3.8.0)
-      rspec-core (~> 3.8.0)
-      rspec-expectations (~> 3.8.0)
-      rspec-mocks (~> 3.8.0)
-    rspec-core (3.8.0)
-      rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.1)
+    minitest (5.12.2)
+    rake (10.5.0)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.0)
+      rspec-support (~> 3.9.0)
+    rspec-expectations (3.9.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.8.0)
-    rspec-mocks (3.8.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.8.0)
-    rspec-support (3.8.0)
-    thor (0.20.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.0)
+    thor (0.20.3)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    zeitwerk (2.2.0)
 
 PLATFORMS
   ruby
@@ -52,4 +54,4 @@ DEPENDENCIES
   talk_like_a_pirate!
 
 BUNDLED WITH
-   1.16.2
+   1.17.1

--- a/talk_like_a_pirate.gemspec
+++ b/talk_like_a_pirate.gemspec
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 Gem::Specification.new do |spec|
   spec.name         = 'talk_like_a_pirate'
-  spec.version      = '0.2.1'
+  spec.version      = '0.2.2'
   spec.authors      = ['Steve Hodges']
   spec.email        = ['shodges317@gmail.com']
   spec.homepage     = 'https://github.com/stevehodges/talk_like_a_pirate'
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.files        = `git ls-files`.split("\n")
   spec.test_files   = `git ls-files -- {spec}/*`.split("\n")
 
-  spec.add_dependency 'activesupport', '>= 3.0.0', '< 6.0.0'
+  spec.add_dependency 'activesupport', '>= 3.0.0', '< 6.0.1'
   spec.add_dependency 'i18n'
 
   spec.add_development_dependency 'appraisal', '~> 2.2'


### PR DESCRIPTION
Hey @stevehodges 

Noticed talk_like_a_pirate needed to support Rails 6 so here you go.

Adding new deps to appraise and run the tests and everything looks goood.

 Let me know if I need to make any changes.

![](https://render.bitstrips.com/v2/cpanel/139d9210-3e24-4ae1-b46c-340632f02735-7bce6184-0c67-4209-b976-bec06e1848e6-v1.png?transparent=1&palette=1)